### PR TITLE
Fix bad url in deleteFile()

### DIFF
--- a/src/S3Proxy.php
+++ b/src/S3Proxy.php
@@ -225,9 +225,6 @@ class S3Proxy
 
 	public function deleteFile($filePath)
 	{
-		if (substr($filePath, 0, 1) != '/') {
-			$filePath = '/'.$filePath;
-		}
 		$result = $this->s3Client->deleteObject(array(
 			'Bucket' => $this->getBucket(),
 			'Key'    => $filePath


### PR DESCRIPTION
There are some new changes in s3client and this line cause problem.
It creates url `bucket-name//file` (AccessDenied) instead of `bucket-name/file`.